### PR TITLE
New feature - SelfEnterAction

### DIFF
--- a/hektor-fsm/src/main/java/io/hektor/fsm/State.java
+++ b/hektor-fsm/src/main/java/io/hektor/fsm/State.java
@@ -53,6 +53,8 @@ public interface State<S extends Enum<S>, C extends Context, D extends Data> {
 
     Optional<BiConsumer<C, D>> getInitialEnterAction();
 
+    Optional<BiConsumer<C, D>> getSelfEnterAction();
+
     Optional<BiConsumer<C, D>> getEnterAction();
 
     Optional<BiConsumer<C, D>> getExitAction();

--- a/hektor-fsm/src/main/java/io/hektor/fsm/builder/StateBuilder.java
+++ b/hektor-fsm/src/main/java/io/hektor/fsm/builder/StateBuilder.java
@@ -12,6 +12,12 @@ public interface StateBuilder<S extends Enum<S>, C extends Context, D extends Da
 
     /**
      * Register an action that will be executed upon entering this state.
+     * This action is ONLY executed when you enter the action from another state. I.e.,
+     * on a transition A -> B, B's enter action would be triggered. However, if you transition
+     * between the same state, so e.g. B -> B, then this enter action will NOT trigger.
+     *
+     * If you wish to trigger an action on "self enter", then use {@link #withSelfEnterAction(BiConsumer)}.
+     *
      */
     StateBuilder<S, C, D> withEnterAction(final BiConsumer<C, D> action);
 
@@ -42,6 +48,15 @@ public interface StateBuilder<S extends Enum<S>, C extends Context, D extends Da
      * @return
      */
     StateBuilder<S, C, D> withInitialEnterAction(final BiConsumer<C, D> action);
+
+    /**
+     * Register an action that will trigger when you transition to/from the same state.
+     * I.e., this action would trigger when you transitioned from B -> B but not A -> B.
+     *
+     * @param action
+     * @return
+     */
+    StateBuilder<S, C, D> withSelfEnterAction(final BiConsumer<C, D> action);
 
     /**
      * Register an action that will be executed upon exiting this state.

--- a/hektor-fsm/src/main/java/io/hektor/fsm/builder/impl/StateBuilderImpl.java
+++ b/hektor-fsm/src/main/java/io/hektor/fsm/builder/impl/StateBuilderImpl.java
@@ -50,6 +50,14 @@ public class StateBuilderImpl<S extends Enum<S>, C extends Context, D extends Da
      * never ever be executed again.
      */
     private BiConsumer<C, D> initialEnterAction;
+
+
+    /**
+     * The "self" enter action is an action that is triggered when you transition
+     * to/from the very same state, such as from state B back to state B.
+     */
+    private BiConsumer<C, D> selfEnterAction;
+
     private BiConsumer<C, D> enterAction;
     private BiConsumer<C, D> exitAction;
 
@@ -81,6 +89,12 @@ public class StateBuilderImpl<S extends Enum<S>, C extends Context, D extends Da
     @Override
     public StateBuilderImpl<S, C, D> withInitialEnterAction(final BiConsumer<C, D> action) {
         initialEnterAction = action;
+        return this;
+    }
+
+    @Override
+    public StateBuilderImpl<S, C, D> withSelfEnterAction(final BiConsumer<C, D> action) {
+        selfEnterAction = action;
         return this;
     }
 
@@ -185,7 +199,7 @@ public class StateBuilderImpl<S extends Enum<S>, C extends Context, D extends Da
 
         final List<Transition<?, S, C, D>> ts = transitions.stream().map(TransitionBuilder::build).collect(Collectors.toList());
         final Optional<Transition<Object, S, C, D>> defaultTs = Optional.ofNullable(defaultTransition == null ? null : defaultTransition.build());
-        return new StateImpl(state, isInitialState, isFinalState, isTransient, ts, defaultTs, initialEnterAction, enterAction, exitAction);
+        return new StateImpl(state, isInitialState, isFinalState, isTransient, ts, defaultTs, initialEnterAction, selfEnterAction, enterAction, exitAction);
     }
 
 

--- a/hektor-fsm/src/main/java/io/hektor/fsm/builder/impl/TransitionBuilderImpl.java
+++ b/hektor-fsm/src/main/java/io/hektor/fsm/builder/impl/TransitionBuilderImpl.java
@@ -38,7 +38,16 @@ public class TransitionBuilderImpl<E extends Object, S extends Enum<S>, C extend
     private Predicate<E> guard;
     private Guard<E, C, D> richerGuard;
 
+    /**
+     * A "simple" action that only takes the event that was processed by the FSM and that triggered
+     * this transition. Compare with the "stateful" action below.
+     */
     private Consumer<E> action;
+
+    /**
+     * A so-called stateful action is an action that not only accept the event but also the {@link Context}
+     * and the {@link Data}-bag.
+     */
     private Action<E, C, D> statefulAction;
 
     /**

--- a/hektor-fsm/src/main/java/io/hektor/fsm/impl/FsmImpl.java
+++ b/hektor-fsm/src/main/java/io/hektor/fsm/impl/FsmImpl.java
@@ -144,6 +144,10 @@ public class FsmImpl<S extends Enum<S>, C extends Context, D extends Data> imple
             if (currentState.getState() != toState) {
                 exitCurrentState();
                 enterState(toState);
+            } else {
+                // "self" transition. I.e. State B -> State B
+                final Optional<BiConsumer<C, D>> action = currentState.getSelfEnterAction();
+                action.ifPresent(a -> a.accept(ctx, data));
             }
 
         } catch(final Throwable t) {

--- a/hektor-fsm/src/main/java/io/hektor/fsm/impl/StateImpl.java
+++ b/hektor-fsm/src/main/java/io/hektor/fsm/impl/StateImpl.java
@@ -25,6 +25,7 @@ public class StateImpl<S extends Enum<S>, C extends Context, D extends Data> imp
     private final List<Transition<?, S, C, D>> transitions;
     private final Optional<Transition<?, S, C, D>> defaultTransition;
     private final Optional<BiConsumer<C, D>> initialEnterAction;
+    private final Optional<BiConsumer<C, D>> selfEnterAction;
     private final Optional<BiConsumer<C, D>> enterAction;
     private final Optional<BiConsumer<C, D>> exitAction;
 
@@ -37,6 +38,7 @@ public class StateImpl<S extends Enum<S>, C extends Context, D extends Data> imp
                      final List<Transition<?, S, C, D>> transitions,
                      final Optional<Transition<?, S, C, D>> defaultTransition,
                      final BiConsumer<C, D> initialEnterAction,
+                     final BiConsumer<C, D> selfEnterAction,
                      final BiConsumer<C, D> enterAction,
                      final BiConsumer<C, D> exitAction) {
         this.state = state;
@@ -46,6 +48,7 @@ public class StateImpl<S extends Enum<S>, C extends Context, D extends Data> imp
         this.transitions = transitions;
         this.defaultTransition = defaultTransition;
         this.initialEnterAction = Optional.ofNullable(initialEnterAction);
+        this.selfEnterAction = Optional.ofNullable(selfEnterAction);
         this.enterAction = Optional.ofNullable(enterAction);
         this.exitAction = Optional.ofNullable(exitAction);
 
@@ -93,6 +96,11 @@ public class StateImpl<S extends Enum<S>, C extends Context, D extends Data> imp
     @Override
     public Optional<BiConsumer<C, D>> getInitialEnterAction() {
         return initialEnterAction;
+    }
+
+    @Override
+    public Optional<BiConsumer<C, D>> getSelfEnterAction() {
+        return selfEnterAction;
     }
 
     @Override


### PR DESCRIPTION
There are times when you have transitions to/from the same state. The
regular "onEnterAction" will not trigger (by design) on a "self"
transition. If this is what you want, there is now a "SelfEnterAction"
you can specify when building out the FSM.