### PR TITLE
Fixed shutdown bug

### DIFF
--- a/hektor-core/src/main/java/io/hektor/core/internal/DefaultHektor.java
+++ b/hektor-core/src/main/java/io/hektor/core/internal/DefaultHektor.java
@@ -124,8 +124,7 @@ public final class DefaultHektor implements InternalHektor {
 
     @Override
     public CompletionStage<Void> terminate() {
-        final CompletableFuture<Void> future = new CompletableFuture<>();
-        return future;
+        return defaultDispatcher.shutdown();
     }
 
     /**

--- a/hektor-core/src/main/java/io/hektor/core/internal/InternalDispatcher.java
+++ b/hektor-core/src/main/java/io/hektor/core/internal/InternalDispatcher.java
@@ -4,6 +4,8 @@ import io.hektor.core.Actor;
 import io.hektor.core.ActorRef;
 import io.hektor.core.Dispatcher;
 
+import java.util.concurrent.CompletionStage;
+
 /**
  * An internal extension to the Dispatcher
  *
@@ -19,4 +21,6 @@ public interface InternalDispatcher extends Dispatcher {
     void register(ActorRef ref, Actor actor);
 
     void unregister(ActorRef ref);
+
+    CompletionStage<Void> shutdown();
 }

--- a/hektor-core/src/main/java/io/hektor/core/internal/workerexecutor/DefaultDispatcher2.java
+++ b/hektor-core/src/main/java/io/hektor/core/internal/workerexecutor/DefaultDispatcher2.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -103,6 +104,11 @@ public class DefaultDispatcher2 implements InternalDispatcher {
     @Override
     public void unregister(final ActorRef ref) {
         actorStore.remove(ref);
+    }
+
+    @Override
+    public CompletionStage<Void> shutdown() {
+        throw new RuntimeException("Not yet implemented - no one should be using this dispatcher");
     }
 
     @Override

--- a/hektor-core/src/test/java/io/hektor/core/HektorStopTest.java
+++ b/hektor-core/src/test/java/io/hektor/core/HektorStopTest.java
@@ -56,19 +56,16 @@ public class HektorStopTest extends HektorTestBase {
      * Ensure we can shut down the entire system.
      * @throws Exception
      */
-    @Ignore
-    @Test(timeout = 500)
+    @Test(timeout = 2000)
     public void testStopHektor() throws Exception {
         final LatchContext latch001 = new LatchContext();
-        final ActorRef parent01 =  defaultHektor.actorOf(latch001.parentProps(), "parent01");
+        defaultHektor.actorOf(latch001.parentProps(), "parent01");
 
         final LatchContext latch002 = new LatchContext();
-        final ActorRef parent02 =  defaultHektor.actorOf(latch002.parentProps(), "parent02");
+        defaultHektor.actorOf(latch002.parentProps(), "parent02");
 
-        defaultHektor.terminate();
-
-        latch001.awaitShutdownLatches();
-        latch002.awaitShutdownLatches();
+        final var future = defaultHektor.terminate();
+        future.toCompletableFuture().get();
     }
 
     /**


### PR DESCRIPTION
Shutdown wasn't properly implemented, now it is :-).

Note: this current shutdown version is quite destructive in that it doesn't allow all potential messages on the internal job queue to finish first. That means that actors may not process all messages that are in the queue. An extension to the current one would perhaps to implement a `shutdown` and a `shutdownNow`, which is a common approach elsewhere.

For now, this current version essentially works as a `shutdownNow`